### PR TITLE
Fix typo in training logs

### DIFF
--- a/build/lib/src/Utilities/rTrain.py
+++ b/build/lib/src/Utilities/rTrain.py
@@ -26,9 +26,9 @@ def r_train():
     else:
         # Code to run if no exception occurred
         end_time = time.time()
-        log.logger.info("\nNo errors occurred DONE SUCESS\nExecution time: %.2f seconds", end_time - start_time)
+        log.logger.info("\nNo errors occurred DONE SUCCESS\nExecution time: %.2f seconds", end_time - start_time)
 
     finally:
         # Code that will run regardless of whether an exception occurred
-        log.logger.critical("\nTrainning EXIT")
+        log.logger.critical("\nTraining EXIT")
         print("\n")

--- a/src/Utilities/rTrain.py
+++ b/src/Utilities/rTrain.py
@@ -26,9 +26,9 @@ def r_train():
     else:
         # Code to run if no exception occurred
         end_time = time.time()
-        log.logger.info("\nNo errors occurred DONE SUCESS\nExecution time: %.2f seconds", end_time - start_time)
+        log.logger.info("\nNo errors occurred DONE SUCCESS\nExecution time: %.2f seconds", end_time - start_time)
 
     finally:
         # Code that will run regardless of whether an exception occurred
-        log.logger.critical("\nTrainning EXIT")
+        log.logger.critical("\nTraining EXIT")
         print("\n")


### PR DESCRIPTION
## Summary
- fix 'SUCCESS' typo in `rTrain` logs
- fix 'Training EXIT' typo in `rTrain` logs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684459cbbe54832ca04041b925bb9ec6