### PR TITLE
Fix OUTPUT dir path

### DIFF
--- a/build/lib/src/Utilities/modelValid.py
+++ b/build/lib/src/Utilities/modelValid.py
@@ -18,7 +18,7 @@ def m_valid():
     start_time = time.time()
     try:
         model = YOLO(mod)
-        results = model.val(project="OUTPUT/Vaild", name=name2)
+        results = model.val(project="OUTPUT/Valid", name=name2)
 
     except Exception as e:
         # Code to handle other exceptions

--- a/src/Utilities/modelValid.py
+++ b/src/Utilities/modelValid.py
@@ -18,7 +18,7 @@ def m_valid():
     start_time = time.time()
     try:
         model = YOLO(mod)
-        results = model.val(project="OUTPUT/Vaild", name=name2)
+        results = model.val(project="OUTPUT/Valid", name=name2)
 
     except Exception as e:
         # Code to handle other exceptions


### PR DESCRIPTION
## Summary
- fix typo in the validation output path

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684459cd8728832c9307578c94900f35