### PR TITLE
Bump version to 1.0.14

### DIFF
--- a/atar.egg-info/PKG-INFO
+++ b/atar.egg-info/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 2.1
 Name: atar
-Version: 1.0.13
+Version: 1.0.14
 Summary: A CLI tool for AI tasks such as dataset handling, training, and validation.
 Home-page: https://github.com/otman-dev/atar-cli
 Author: MOUHIB Otman
@@ -10,6 +10,3 @@ Classifier: License :: OSI Approved :: MIT License
 Classifier: Operating System :: OS Independent
 Requires-Python: >=3.6
 License-File: LICENSE
-Requires-Dist: ultralytics
-Requires-Dist: roboflow
-Requires-Dist: supervision

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="atar",
-    version="1.0.13",
+    version="1.0.14",
     description="A CLI tool for AI tasks such as dataset handling, training, and validation.",
     author="MOUHIB Otman",
     author_email="mouhib.otm@gmail.com",


### PR DESCRIPTION
## Summary
- bump package version to 1.0.14 for the next PyPI release

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684469d3f368832c9e37a80e0f61899d