### PR TITLE
Fix missing PyPI description

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 include README.md
 include LICENSE
-recursive-include your_package *.py
+recursive-include atar *.py

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,14 @@
 from setuptools import setup, find_packages
 
+with open("README.md", "r", encoding="utf-8") as fh:
+    long_description = fh.read()
+
 setup(
     name="atar",
     version="1.0.14",
     description="A CLI tool for AI tasks such as dataset handling, training, and validation.",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
     author="MOUHIB Otman",
     author_email="mouhib.otm@gmail.com",
     url="https://github.com/otman-dev/atar-cli",  # Replace with your GitHub repo URL


### PR DESCRIPTION
## Summary
- include README in the long description
- fix MANIFEST to package sources

## Testing
- `pytest -q`
- `python setup.py sdist bdist_wheel` *(fails: invalid command 'bdist_wheel')*

------
https://chatgpt.com/codex/tasks/task_e_684471a85894832c9d99b82572ced22c